### PR TITLE
upgrade igvjs version to handle igv.org outages

### DIFF
--- a/jigv-template.html
+++ b/jigv-template.html
@@ -8,7 +8,7 @@
     <meta name="author" content="Joe Brown" />
     <title>jigv - easy self-contained igv.js reports</title>
 
-    <script src="https://cdn.jsdelivr.net/npm/igv@2.8.5/dist/igv.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/igv@2.15.0/dist/igv.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.4.1/js/bootstrap.bundle.min.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Patrick+Hand&display=swap">
@@ -109,7 +109,7 @@
         let cache = []
         let browser
 
-        
+
 
         $("#previous-feature").click(function () {
             var e = jQuery.Event("keydown")
@@ -181,14 +181,14 @@
 			// one that we clicked on. need to count <hr> and reset.
             data.forEach(function (kv) {
 				if(done){ return; }
-                if (!kv.name) { 
+                if (!kv.name) {
 					if(kv.startsWith("--------")){
 						if(d["Read Base:"]) { done=true; return; }
 						hr = 0;
 						d.tags = []
 						return
 					} else {
-						hr += 1; return 
+						hr += 1; return
 					}
 				}
                 if (hr == 3) {


### PR DESCRIPTION
Hi @brentp, 

I found that my `jigv` reports have been broken for a couple of days, because `igv.js` dependency relies on this endpoint https://igv.org/genomes/genomes.json that is currently down. See [here](https://github.com/igvteam/igv.js/blob/v2.8.5/js/genome/genome.js#L33) in current version `v2.8.5`.

This has been fixed since `v2.8.6`, where a [commit](https://github.com/igvteam/igv.js/commit/634c2c9537028939611d2b837a4279b160906d04) was made to try a backup url

This PR is to upgrade `jigv` to latest version, which fixes the issue with the report.